### PR TITLE
Allow 'j-*j ban '.cc-*' and '.jui-*'

### DIFF
--- a/lib/ProtectCmsLinter.js
+++ b/lib/ProtectCmsLinter.js
@@ -3,6 +3,7 @@
 var parseCss = require('css').parse;
 var noBareElement = require('./rules/noBareElement');
 var protectedNamespace = require('./rules/protectedNamespace');
+var semiProtectedNamespace = require('./rules/semiProtectedNamespace');
 var CONSTANTS = require('./CONSTANTS');
 
 class ProtectCmsLinter {
@@ -70,7 +71,8 @@ class ProtectCmsLinter {
 
 ProtectCmsLinter.defaultRules = {
   noBareElement,
-  protectedNamespace
+  protectedNamespace,
+  semiProtectedNamespace
 };
 
 module.exports = ProtectCmsLinter;

--- a/lib/rules/protectedNamespace.js
+++ b/lib/rules/protectedNamespace.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const PROTECTED_NAMESPACE = [
-  '.j-',
-  '.cc-m'
+const PROTECTED_NAMESPACES = [
+  '.cc-',
+  '.jui-'
 ];
 
 function forEachSubselector(selectors, cb) {
@@ -12,11 +12,9 @@ function forEachSubselector(selectors, cb) {
 }
 
 module.exports = function noBareElement(rule) {
-  PROTECTED_NAMESPACE.forEach((protectedNamespace) => {
+  PROTECTED_NAMESPACES.forEach((protectedNamespace) => {
     forEachSubselector(rule.selectors, (subselector) => {
-      const withoutModule = subselector.replace('.j-module', '');
-
-      if (withoutModule.indexOf(protectedNamespace) !== -1) {
+      if (subselector.indexOf(protectedNamespace) !== -1) {
         throw new Error(`illegal use of "${protectedNamespace}"...`);
       }
     });

--- a/lib/rules/semiProtectedNamespace.js
+++ b/lib/rules/semiProtectedNamespace.js
@@ -14,7 +14,11 @@ module.exports = function noBareElement(rule) {
     const subselectors = selector.split(' ');
 
     subselectors.forEach((subselector, index) => {
-      if (hadExclusion || EXCLUSION_ZONE.test(subselector)) {
+      if (hadExclusion) {
+        return;
+      }
+
+      if (EXCLUSION_ZONE.test(subselector)) {
         hadExclusion = true;
         return;
       }

--- a/lib/rules/semiProtectedNamespace.js
+++ b/lib/rules/semiProtectedNamespace.js
@@ -27,7 +27,7 @@ module.exports = function noBareElement(rule) {
         index < subselectors.length - 1
       ) {
         throw new Error(`${SEMI_PROTECTED_NAMESPACE}* selector ` +
-          `must be the hindmost`);
+          `must be the last`);
       }
     });
   });

--- a/lib/rules/semiProtectedNamespace.js
+++ b/lib/rules/semiProtectedNamespace.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const SEMI_PROTECTED_NAMESPACE = '.j-';
+const EXCLUSION_ZONE = /\.j-module-content$/;
+
+module.exports = function noBareElement(rule) {
+  rule.selectors.forEach((selector) => {
+    var hadExclusion = false;
+
+    if (selector.indexOf(SEMI_PROTECTED_NAMESPACE) === -1) {
+      return;
+    }
+
+    const subselectors = selector.split(' ');
+
+    subselectors.forEach((subselector, index) => {
+      if (hadExclusion || EXCLUSION_ZONE.test(subselector)) {
+        hadExclusion = true;
+        return;
+      }
+
+      if (subselector.indexOf(SEMI_PROTECTED_NAMESPACE) !== -1 &&
+        index < subselectors.length - 1
+      ) {
+        throw new Error(`${SEMI_PROTECTED_NAMESPACE}* selector ` +
+          `must be the hindmost`);
+      }
+    });
+  });
+};

--- a/test/fixtures/bad/disguised-module-content-namespace+element.css
+++ b/test/fixtures/bad/disguised-module-content-namespace+element.css
@@ -1,0 +1,3 @@
+.j-module-contentus div {
+  color: red;
+}

--- a/test/fixtures/bad/element+protected-namespace.css
+++ b/test/fixtures/bad/element+protected-namespace.css
@@ -1,3 +1,3 @@
-div.j-foo {
+div.cc-foo {
   color: transparent;
 }

--- a/test/fixtures/bad/nested+protected-namespace-j.css
+++ b/test/fixtures/bad/nested+protected-namespace-j.css
@@ -1,3 +1,3 @@
-.my-foo .j-bar {
+.my-foo .cc-bar {
   color: red;
 }

--- a/test/fixtures/bad/ok-namespace+protected-namespace-j.css
+++ b/test/fixtures/bad/ok-namespace+protected-namespace-j.css
@@ -1,3 +1,3 @@
-.my-foo.j-bar {
+.my-foo.cc-bar {
   text-decoration: underline;
 }

--- a/test/fixtures/bad/semi-protected-namespace-j+ok-namespace.css
+++ b/test/fixtures/bad/semi-protected-namespace-j+ok-namespace.css
@@ -1,0 +1,3 @@
+.j-bar .foo {
+  border: 10px solid black;
+}

--- a/test/fixtures/bad/ui-library-namespace+ok-namespace.css
+++ b/test/fixtures/bad/ui-library-namespace+ok-namespace.css
@@ -1,3 +1,3 @@
-.j-bar {
+.jui-foo .my-bar {
   border: 10px solid black;
 }

--- a/test/fixtures/bad/ui-library-namespace.css
+++ b/test/fixtures/bad/ui-library-namespace.css
@@ -1,3 +1,3 @@
-.cc-irgendwas {
+.jui-irgendwas {
   margin: 5px;
 }

--- a/test/fixtures/good/module-content-namespace+element+modifier.css
+++ b/test/fixtures/good/module-content-namespace+element+modifier.css
@@ -1,0 +1,3 @@
+.j-module-content a:hover {
+  top: -2px;
+}

--- a/test/fixtures/good/module-content-namespace+element.css
+++ b/test/fixtures/good/module-content-namespace+element.css
@@ -1,3 +1,3 @@
-.j-module div {
+.j-module-content div {
   background-color: blue;
 }

--- a/test/fixtures/good/module-namespace+element+modifier.css
+++ b/test/fixtures/good/module-namespace+element+modifier.css
@@ -1,3 +1,0 @@
-.j-module a:hover {
-  top: -2px;
-}

--- a/test/fixtures/good/ok-namespace+module-content-namespace+element.css
+++ b/test/fixtures/good/ok-namespace+module-content-namespace+element.css
@@ -1,0 +1,3 @@
+.foo .j-module-content div {
+    padding: 5px;
+}

--- a/test/fixtures/good/ok-namespace+module-namespace+element.css
+++ b/test/fixtures/good/ok-namespace+module-namespace+element.css
@@ -1,3 +1,0 @@
-.foo .j-module div {
-    padding: 5px;
-}

--- a/test/fixtures/good/ok-namespace+semi-protected-namespace.css
+++ b/test/fixtures/good/ok-namespace+semi-protected-namespace.css
@@ -1,0 +1,3 @@
+.foo .j-something {
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
As discussed with @progsource, @bjoernjimdo, @timse and @jimdo-lars 

New rules
- all use of `.cc-*` and `.jui-*` is now prohibited
- use of `.j-*` must be at the very end of a selector
- `.j-module-content` is the new "everything is allowed from here on"

PTAL @Jimdo/ui-librarians 

especially the [new fixtures](https://github.com/Jimdo/protect-cms-linter/tree/158d193417cebd06e1422cc95cdf4ee99c23e99f/test/fixtures)
